### PR TITLE
chore: 🔨 add biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.3/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": []
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space"
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "dev": "plasmo dev",
     "build": "plasmo build",
     "test": "jest",
-    "lint": "eslint . --ext .ts,.tsx",
-    "format": "prettier --write \"**/*.{ts,tsx,json}\"",
+    "lint": "biome check",
+    "format": "biome check --write",
     "ai": "tsx scripts/genAi.ts"
   },
   "dependencies": {
@@ -33,6 +33,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.9.3",
     "@ianvs/prettier-plugin-sort-imports": "4.1.1",
     "@radix-ui/react-menubar": "^1.1.1",
     "@radix-ui/react-scroll-area": "^1.1.0",
@@ -60,30 +61,18 @@
     "typescript": "5.5.4"
   },
   "manifest": {
-    "permissions": [
-      "contextMenus",
-      "tabs",
-      "storage",
-      "alarms",
-      "activeTab"
-    ],
+    "permissions": ["contextMenus", "tabs", "storage", "alarms", "activeTab"],
     "background": {
       "service_worker": "background.ts"
     },
     "name": "tsw - tiny smart worker",
     "description": "Your tiny smart worker",
     "version": "0.1.0",
-    "host_permissions": [
-      "https://*/*"
-    ],
+    "host_permissions": ["https://*/*"],
     "content_scripts": [
       {
-        "matches": [
-          "<all_urls>"
-        ],
-        "css": [
-          "/src/css/global.css"
-        ],
+        "matches": ["<all_urls>"],
+        "css": ["/src/css/global.css"],
         "run_at": "document_start"
       }
     ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
         specifier: ^3.23.8
         version: 3.23.8
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.3
+        version: 1.9.3
       '@ianvs/prettier-plugin-sort-imports':
         specifier: 4.1.1
         version: 4.1.1(@vue/compiler-sfc@3.2.45)(prettier@2.8.8)
@@ -318,6 +321,63 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@biomejs/biome@1.9.3':
+    resolution: {integrity: sha512-POjAPz0APAmX33WOQFGQrwLvlu7WLV4CFJMlB12b6ZSg+2q6fYu9kZwLCOA+x83zXfcPd1RpuWOKJW0GbBwLIQ==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@1.9.3':
+    resolution: {integrity: sha512-QZzD2XrjJDUyIZK+aR2i5DDxCJfdwiYbUKu9GzkCUJpL78uSelAHAPy7m0GuPMVtF/Uo+OKv97W3P9nuWZangQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.3':
+    resolution: {integrity: sha512-vSCoIBJE0BN3SWDFuAY/tRavpUtNoqiceJ5PrU3xDfsLcm/U6N93JSM0M9OAiC/X7mPPfejtr6Yc9vSgWlEgVw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@1.9.3':
+    resolution: {integrity: sha512-VBzyhaqqqwP3bAkkBrhVq50i3Uj9+RWuj+pYmXrMDgjS5+SKYGE56BwNw4l8hR3SmYbLSbEo15GcV043CDSk+Q==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@1.9.3':
+    resolution: {integrity: sha512-vJkAimD2+sVviNTbaWOGqEBy31cW0ZB52KtpVIbkuma7PlfII3tsLhFa+cwbRAcRBkobBBhqZ06hXoZAN8NODQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@1.9.3':
+    resolution: {integrity: sha512-TJmnOG2+NOGM72mlczEsNki9UT+XAsMFAOo8J0me/N47EJ/vkLXxf481evfHLlxMejTY6IN8SdRSiPVLv6AHlA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@1.9.3':
+    resolution: {integrity: sha512-x220V4c+romd26Mu1ptU+EudMXVS4xmzKxPVb9mgnfYlN4Yx9vD5NZraSx/onJnd3Gh/y8iPUdU5CDZJKg9COA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@1.9.3':
+    resolution: {integrity: sha512-lg/yZis2HdQGsycUvHWSzo9kOvnGgvtrYRgoCEwPBwwAL8/6crOp3+f47tPwI/LI1dZrhSji7PNsGKGHbwyAhw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.3':
+    resolution: {integrity: sha512-cQMy2zanBkVLpmmxXdK6YePzmZx0s5Z7KEnwmrW54rcXK3myCNbQa09SwGZ8i/8sLw0H9F3X7K4rxVNGU8/D4Q==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@esbuild/aix-ppc64@0.23.1':
     resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
@@ -3601,48 +3661,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.26.0:
     resolution: {integrity: sha512-iJmZM7fUyVjH+POtdiCtExG+67TtPUTer7K/5A8DIfmPfrmeGvzfRyBltGhQz13Wi15K1lf2cPYoRaRh6vcwNA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.18.0:
     resolution: {integrity: sha512-2FWHa8iUhShnZnqhn2wfIcK5adJat9hAAaX7etNsoXJymlliDIOFuBQEsba2KBAZSM4QqfQtvRdR7m8i0I7ybQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.26.0:
     resolution: {integrity: sha512-XxoEL++tTkyuvu+wq/QS8bwyTXZv2y5XYCMcWL45b8XwkiS8eEEEej9BkMGSRwxa5J4K+LDeIhLrS23CpQyfig==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.18.0:
     resolution: {integrity: sha512-plCPGQJtDZHcLVKVRLnQVF2XRsIC32WvuJhQ7fJ7F6BV98b/VZX0OlX05qUaOESD9dCDHjYSfxsgcvOKgCWh7A==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.26.0:
     resolution: {integrity: sha512-1dkTfZQAYLj8MUSkd6L/+TWTG8V6Kfrzfa0T1fSlXCXQHrt1HC1/UepXHtKHDt/9yFwyoeayivxXAsApVxn6zA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.18.0:
     resolution: {integrity: sha512-na+BGtVU6fpZvOHKhnlA0XHeibkT3/46nj6vLluG3kzdJYoBKU6dIl7DSOk++8jv4ybZyFJ0aOFMMSc8g2h58A==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.26.0:
     resolution: {integrity: sha512-yX3Rk9m00JGCUzuUhFEojY+jf/6zHs3XU8S8Vk+FRbnr4St7cjyMXdNjuA2LjiT8e7j8xHRCH8hyZ4H/btRE4A==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.26.0:
     resolution: {integrity: sha512-X/597/cFnCogy9VItj/+7Tgu5VLbAtDF7KZDPdSw0MaL6FL940th1y3HiOzFIlziVvAtbo0RB3NAae1Oofr+Tw==}
@@ -5214,6 +5282,41 @@ snapshots:
       to-fast-properties: 2.0.0
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@biomejs/biome@1.9.3':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.3
+      '@biomejs/cli-darwin-x64': 1.9.3
+      '@biomejs/cli-linux-arm64': 1.9.3
+      '@biomejs/cli-linux-arm64-musl': 1.9.3
+      '@biomejs/cli-linux-x64': 1.9.3
+      '@biomejs/cli-linux-x64-musl': 1.9.3
+      '@biomejs/cli-win32-arm64': 1.9.3
+      '@biomejs/cli-win32-x64': 1.9.3
+
+  '@biomejs/cli-darwin-arm64@1.9.3':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.3':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@1.9.3':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.3':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@1.9.3':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.3':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@1.9.3':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.3':
+    optional: true
 
   '@esbuild/aix-ppc64@0.23.1':
     optional: true


### PR DESCRIPTION
Use case: OCR and translate.

```ts
await ocr(imgBuffer, "image/png", "Translate the text into Chinese")
```

Sample:

![test3](https://github.com/user-attachments/assets/a52f59c4-02fd-48e3-ad47-403676d06858)

Result:

```html
<pre><p>Glob syntax explained</p>
<p>A glob pattern specifies a set of filenames. Biome supports the following globs:</p>
<ul>
<li><code>*</code> matches zero or more characters. It cannot match the path separator <code>/</code>.</li>
<li><code>**</code> recursively matches directories and files. This sequence <strong>must</strong> form a single path component, so both <code>**a</code> and <code>**b</code> are invalid and will result in an error. A sequence of more than two consecutive <code>*</code> characters is also invalid.</li>
<li><code>[...]</code> matches any character inside the brackets. Ranges of characters can also be specified, as ordered by Unicode, so e.g. <code>[0-9]</code> specifies any character between 0 and 9 inclusive.</li>
<li><code>[!...]</code> is the negation of <code>[...]</code>, i.e. it matches any characters <strong>not</strong> in the brackets.</li>
</ul>
<p>Some examples:</p>
<ul>
<li><code>dist/**</code> matches the dist directory and all files in this directory.</li>
<li><code>**/test/**</code> matches all files under any directory named <code>test</code>, regardless of where they are. E.g. <code>dist/test</code>, <code>src/test</code>.</li>
<li><code>**/*.js</code> matches all files ending with the extension <code>.js</code> in all directories.</li>
</ul>
<p>Biome uses a glob library that treats all globs as having a <code>**/</code> prefix. This means that <code>src/**/*.js</code> and <code>**src/**/*.js</code> are treated as identical. They match both <code>src/file.js</code> and <code>test/src/file.js</code>.</p>
<p>全局语法说明</p>
<p>一个 glob 模式指定一组文件名。Biome 支持以下 glob：</p>
<ul>
<li><code>*</code> 匹配零个或多个字符。它不能匹配路径分隔符 <code>/</code>。</li>
<li><code>**</code> 递归匹配目录和文件。此序列 <strong>必须</strong> 形成一个单一路径组件，因此 <code>**a</code> 和 <code>**b</code> 都无效，并将导致错误。两个以上连续 <code>*</code> 字符的序列也是无效的。</li>
<li><code>[...]</code> 匹配括号内的任何字符。字符范围也可以指定，按 Unicode 排序，例如 <code>[0-9]</code> 指定 0 到 9 之间的任何字符（包含）。</li>
<li><code>[!...]</code> 是 <code>[...]</code> 的否定，即它匹配 <strong>不</strong> 在括号内的任何字符。</li>
</ul>
<p>一些示例：</p>
<ul>
<li><code>dist/**</code> 匹配 dist 目录及其中的所有文件。</li>
<li><code>**/test/**</code> 匹配名为 <code>test</code> 的任何目录下的所有文件，无论它们在哪里。例如 <code>dist/test</code>、<code>src/test</code>。</li>
<li><code>**/*.js</code> 匹配所有以扩展名 <code>.js</code> 结尾的文件，位于所有目录中。</li>
</ul>
<p>Biome 使用一个 glob 库，它将所有 glob 视为具有 <code>**/</code> 前缀。这意味着 <code>src/**/*.js</code> 和 <code>**src/**/*.js</code> 被视为相同。它们都匹配 <code>src/file.js</code> 和 <code>test/src/file.js</code>。</p>
</pre
```