### PR TITLE
feat: 🎸 add postPrompt to OCR, will support more actions after OCR

### DIFF
--- a/src/utils/ai.ts
+++ b/src/utils/ai.ts
@@ -87,13 +87,13 @@ export const rewriteCode = (code: string, targetLang: string) =>
 
 // TODO: Use some external image APIs for image preprocessing
 // (noise reduction, binarization, deskewing, sharpening, and so on)
-export const ocr = (imageBuffer: Buffer, imageMimeType: string) =>
+export const ocr = (imageBuffer: Buffer, imageMimeType: string, postPrompt = "") =>
   genAIFunction(
     [
       {
         inlineData: { mimeType: imageMimeType, data: imageBuffer.toString("base64") },
       },
     ],
-    ocrExpert,
+    ocrExpert + postPrompt,
     true
   );


### PR DESCRIPTION
Use case: OCR and translate.

```ts
await ocr(imgBuffer, "image/png", "Translate the text into Chinese")
```

Sample:

![test3](https://github.com/user-attachments/assets/a52f59c4-02fd-48e3-ad47-403676d06858)

Result:

```html
<pre><p>Glob syntax explained</p>
<p>A glob pattern specifies a set of filenames. Biome supports the following globs:</p>
<ul>
<li><code>*</code> matches zero or more characters. It cannot match the path separator <code>/</code>.</li>
<li><code>**</code> recursively matches directories and files. This sequence <strong>must</strong> form a single path component, so both <code>**a</code> and <code>**b</code> are invalid and will result in an error. A sequence of more than two consecutive <code>*</code> characters is also invalid.</li>
<li><code>[...]</code> matches any character inside the brackets. Ranges of characters can also be specified, as ordered by Unicode, so e.g. <code>[0-9]</code> specifies any character between 0 and 9 inclusive.</li>
<li><code>[!...]</code> is the negation of <code>[...]</code>, i.e. it matches any characters <strong>not</strong> in the brackets.</li>
</ul>
<p>Some examples:</p>
<ul>
<li><code>dist/**</code> matches the dist directory and all files in this directory.</li>
<li><code>**/test/**</code> matches all files under any directory named <code>test</code>, regardless of where they are. E.g. <code>dist/test</code>, <code>src/test</code>.</li>
<li><code>**/*.js</code> matches all files ending with the extension <code>.js</code> in all directories.</li>
</ul>
<p>Biome uses a glob library that treats all globs as having a <code>**/</code> prefix. This means that <code>src/**/*.js</code> and <code>**src/**/*.js</code> are treated as identical. They match both <code>src/file.js</code> and <code>test/src/file.js</code>.</p>
<p>全局语法说明</p>
<p>一个 glob 模式指定一组文件名。Biome 支持以下 glob：</p>
<ul>
<li><code>*</code> 匹配零个或多个字符。它不能匹配路径分隔符 <code>/</code>。</li>
<li><code>**</code> 递归匹配目录和文件。此序列 <strong>必须</strong> 形成一个单一路径组件，因此 <code>**a</code> 和 <code>**b</code> 都无效，并将导致错误。两个以上连续 <code>*</code> 字符的序列也是无效的。</li>
<li><code>[...]</code> 匹配括号内的任何字符。字符范围也可以指定，按 Unicode 排序，例如 <code>[0-9]</code> 指定 0 到 9 之间的任何字符（包含）。</li>
<li><code>[!...]</code> 是 <code>[...]</code> 的否定，即它匹配 <strong>不</strong> 在括号内的任何字符。</li>
</ul>
<p>一些示例：</p>
<ul>
<li><code>dist/**</code> 匹配 dist 目录及其中的所有文件。</li>
<li><code>**/test/**</code> 匹配名为 <code>test</code> 的任何目录下的所有文件，无论它们在哪里。例如 <code>dist/test</code>、<code>src/test</code>。</li>
<li><code>**/*.js</code> 匹配所有以扩展名 <code>.js</code> 结尾的文件，位于所有目录中。</li>
</ul>
<p>Biome 使用一个 glob 库，它将所有 glob 视为具有 <code>**/</code> 前缀。这意味着 <code>src/**/*.js</code> 和 <code>**src/**/*.js</code> 被视为相同。它们都匹配 <code>src/file.js</code> 和 <code>test/src/file.js</code>。</p>
</pre
```